### PR TITLE
Add missing semicolon on line 82

### DIFF
--- a/03_Laravel/09_Routes.md
+++ b/03_Laravel/09_Routes.md
@@ -79,7 +79,7 @@ To demonstrate this, replace the above /books/show route with this updated versi
 Route::get('/books/show/{title?}', function($title = '') {
 
     if($title == '') {
-        return 'Your request did not include a title.'
+        return 'Your request did not include a title.';
     }
 
 	return 'Results for the book: '.$title;


### PR DESCRIPTION
Missing semicolon in sample `Route::get('/books/show/{title?}', function($title = '')`